### PR TITLE
880 strict schema

### DIFF
--- a/janusgraph-core/src/main/java/org/janusgraph/core/EdgeLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/EdgeLabel.java
@@ -15,6 +15,8 @@
 
 package org.janusgraph.core;
 
+import java.util.Collection;
+
 /**
  * EdgeLabel is an extension of {@link RelationType} for edges. Each edge in JanusGraph has a label.
  * <p/>
@@ -54,5 +56,12 @@ public interface EdgeLabel extends RelationType {
      * @return
      */
     Multiplicity multiplicity();
+
+    /**
+     * Collects all property constraints.
+     *
+     * @return a list of {@link PropertyKey} which represents all property constraints for a {@link EdgeLabel}.
+     */
+    Collection<PropertyKey> mappedProperties();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/VertexConnection.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/VertexConnection.java
@@ -1,0 +1,46 @@
+// Copyright 2018 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.core;
+
+/**
+ * @author Jan Jansen (jan.jansen@gdata.de)
+ */
+public class VertexConnection {
+    private final VertexLabel incomingVertexLabel;
+    private final String edgeLabel;
+
+    public VertexConnection(VertexLabel incomingVertexLabel, String edgeLabel) {
+        this.incomingVertexLabel = incomingVertexLabel;
+        this.edgeLabel = edgeLabel;
+    }
+
+    /**
+     *
+     *
+     * @return a incoming {@link VertexLabel}.
+     */
+    public VertexLabel getIncomingVertexLabel() {
+        return incomingVertexLabel;
+    }
+
+    /**
+     * Edge for an vertex connection
+     *
+     * @return a label from an {@link EdgeLabel}.
+     */
+    public String getEdgeLabel() {
+        return edgeLabel;
+    }
+}

--- a/janusgraph-core/src/main/java/org/janusgraph/core/VertexLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/VertexLabel.java
@@ -16,6 +16,8 @@ package org.janusgraph.core;
 
 import org.janusgraph.core.schema.JanusGraphSchemaType;
 
+import java.util.Collection;
+
 /**
  * A vertex label is a label attached to vertices in a JanusGraph graph. This can be used to define the nature of a
  * vertex.
@@ -43,5 +45,18 @@ public interface VertexLabel extends JanusGraphVertex, JanusGraphSchemaType {
 
     //TTL
 
+    /**
+     * Collects all property constraints.
+     *
+     * @return a list of {@link PropertyKey} which represents all property constraints for a {@link VertexLabel}.
+     */
+    Collection<PropertyKey> mappedProperties();
+
+    /**
+     * Collects all connection constraints.
+     *
+     * @return a list of {@link VertexConnection} which represents all connection constraints for a {@link VertexLabel}.
+     */
+    Collection<VertexConnection> mappedConnections();
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/DefaultSchemaMaker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/DefaultSchemaMaker.java
@@ -93,6 +93,41 @@ public interface DefaultSchemaMaker {
      */
     boolean ignoreUndefinedQueryTypes();
 
+    /**
+     * Add property constraints for a given vertex label using the schema manager.
+     *
+     * @param vertexLabel to which the constraint applies.
+     * @param key defines the property which should be added to the vertex label as a constraint.
+     * @param manager is used to update the schema.
+     * @see org.janusgraph.core.schema.SchemaManager
+     */
+    default void makePropertyConstraintForVertex(VertexLabel vertexLabel, PropertyKey key, SchemaManager manager) {
+        manager.addProperties(vertexLabel, key);
+    }
 
+    /**
+     * Add property constraints for a given edge label using the schema manager.
+     *
+     * @param edgeLabel to which the constraint applies.
+     * @param key defines the property which should be added to the edge label as a constraint.
+     * @param manager is used to update the schema.
+     * @see org.janusgraph.core.schema.SchemaManager
+     */
+    default void makePropertyConstraintForEdge(EdgeLabel edgeLabel, PropertyKey key, SchemaManager manager) {
+        manager.addProperties(edgeLabel, key);
+    }
+
+    /**
+     * Add a constraint on which vertices the given edge label can connect using the schema manager.
+     *
+     * @param edgeLabel to which the constraint applies.
+     * @param outVLabel specifies the outgoing vertex for this connection.
+     * @param inVLabel specifies the incoming vertex for this connection.
+     * @param manager is used to update the schema.
+     * @see org.janusgraph.core.schema.SchemaManager
+     */
+    default void makeConnectionConstraint(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel, SchemaManager manager) {
+        manager.addConnection(edgeLabel, outVLabel, inVLabel);
+    }
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/core/schema/SchemaManager.java
@@ -14,6 +14,10 @@
 
 package org.janusgraph.core.schema;
 
+import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.VertexLabel;
+
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
@@ -53,6 +57,34 @@ public interface SchemaManager extends SchemaInspector {
      * @return
      */
     VertexLabelMaker makeVertexLabel(String name);
+
+    /**
+     * Add property constraints for a given vertex label.
+     *
+     * @param vertexLabel to which the constraints applies.
+     * @param keys defines the properties which should be added to the {@link VertexLabel} as constraints.
+     * @return a {@link VertexLabel} edited which contains the added constraints.
+     */
+    VertexLabel addProperties(VertexLabel vertexLabel, PropertyKey... keys);
+
+    /**
+     * Add property constraints for a given edge label.
+     *
+     * @param edgeLabel to which the constraints applies.
+     * @param keys defines the properties which should be added to the {@link EdgeLabel} as constraints.
+     * @return a {@link EdgeLabel} edited which contains the added constraints.
+     */
+    EdgeLabel addProperties(EdgeLabel edgeLabel, PropertyKey... keys);
+
+    /**
+     * Add a constraint on which vertices the given edge label can connect.
+     *
+     * @param edgeLabel to which the constraint applies.
+     * @param outVLabel specifies the outgoing vertex for this connection.
+     * @param inVLabel specifies the incoming vertex for this connection.
+     * @return a {@link EdgeLabel} edited which contains the added constraint.
+     */
+    EdgeLabel addConnection(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel);
 
 
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -273,7 +273,7 @@ public class GraphDatabaseConfiguration {
     public static final ConfigOption<String> AUTO_TYPE = new ConfigOption<>(SCHEMA_NS,"default",
             "Configures the DefaultSchemaMaker to be used by this graph. If set to 'none', automatic schema creation is disabled. " +
                     "Defaults to a blueprints compatible schema maker with MULTI edge labels and SINGLE property keys",
-            ConfigOption.Type.MASKABLE, "default" , new Predicate<String>() {
+            ConfigOption.Type.MASKABLE, "default", new Predicate<String>() {
         @Override
         public boolean apply(@Nullable String s) {
             if (s==null) return false;
@@ -292,6 +292,10 @@ public class GraphDatabaseConfiguration {
                     "default", JanusGraphDefaultSchemaMaker.INSTANCE,
                     "tp3", Tp3DefaultSchemaMaker.INSTANCE);
 
+    public static final ConfigOption<Boolean> SCHEMA_CONSTRAINTS = new ConfigOption<>(SCHEMA_NS, "constraints",
+        "Configures the schema constraints to be used by this graph. If set to 'false', no constraints are applied. " +
+            "If set to 'true', constraints on properties per label and possible connections are enforced.",
+        ConfigOption.Type.MASKABLE, false);
 
     // ################ CACHE #######################
     // ################################################
@@ -1208,6 +1212,7 @@ public class GraphDatabaseConfiguration {
     private int txVertexCacheSize;
     private int txDirtyVertexSize;
     private DefaultSchemaMaker defaultSchemaMaker;
+    private boolean hasDisabledSchemaConstraints;
     private Boolean propertyPrefetching;
     private boolean adjustQueryLimit;
     private Boolean useMultiQuery;
@@ -1492,6 +1497,8 @@ public class GraphDatabaseConfiguration {
         //Disable auto-type making when batch-loading is enabled since that may overwrite types without warning
         if (batchLoading) defaultSchemaMaker = DisableDefaultSchemaMaker.INSTANCE;
 
+        hasDisabledSchemaConstraints = !configuration.get(SCHEMA_CONSTRAINTS);
+
         txVertexCacheSize = configuration.get(TX_CACHE_SIZE);
         //Check for explicit dirty vertex cache size first, then fall back on batch-loading-dependent default
         if (configuration.has(TX_DIRTY_SIZE)) {
@@ -1632,6 +1639,10 @@ public class GraphDatabaseConfiguration {
 
     public DefaultSchemaMaker getDefaultSchemaMaker() {
         return defaultSchemaMaker;
+    }
+
+    public boolean hasDisabledSchemaConstraints() {
+        return hasDisabledSchemaConstraints;
     }
 
     public boolean allowVertexIdSetting() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/StandardEdge.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/StandardEdge.java
@@ -77,6 +77,7 @@ public class StandardEdge extends AbstractEdge implements StandardRelation, Reas
                 }
             }
         }
+        tx().checkPropertyConstraintForEdgeOrCreateConstraint(edgeLabel(), key);
         properties.put(key, value);
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/tinkerpop/JanusGraphBlueprintsGraph.java
@@ -212,6 +212,21 @@ public abstract class JanusGraphBlueprintsGraph implements JanusGraph {
     }
 
     @Override
+    public VertexLabel addProperties(VertexLabel vertexLabel, PropertyKey... keys) {
+        return getAutoStartTx().addProperties(vertexLabel, keys);
+    }
+
+    @Override
+    public EdgeLabel addProperties(EdgeLabel edgeLabel, PropertyKey... keys) {
+        return getAutoStartTx().addProperties(edgeLabel, keys);
+    }
+
+    @Override
+    public EdgeLabel addConnection(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel) {
+        return getAutoStartTx().addConnection(edgeLabel, outVLabel, inVLabel);
+    }
+
+    @Override
     public boolean containsPropertyKey(String name) {
         return getAutoStartTx().containsPropertyKey(name);
     }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java
@@ -31,7 +31,7 @@ import org.janusgraph.diskstorage.BackendTransaction;
 import org.janusgraph.diskstorage.EntryList;
 import org.janusgraph.diskstorage.keycolumnvalue.SliceQuery;
 import org.janusgraph.graphdb.query.profile.QueryProfiler;
-import org.janusgraph.graphdb.relations.RelationComparator;
+import org.janusgraph.graphdb.relations.*;
 import org.janusgraph.graphdb.tinkerpop.JanusGraphBlueprintsTransaction;
 import org.janusgraph.graphdb.database.EdgeSerializer;
 import org.janusgraph.graphdb.database.IndexSerializer;
@@ -49,9 +49,6 @@ import org.janusgraph.graphdb.query.graph.JointIndexQuery;
 import org.janusgraph.graphdb.query.vertex.MultiVertexCentricQueryBuilder;
 import org.janusgraph.graphdb.query.vertex.VertexCentricQuery;
 import org.janusgraph.graphdb.query.vertex.VertexCentricQueryBuilder;
-import org.janusgraph.graphdb.relations.RelationIdentifier;
-import org.janusgraph.graphdb.relations.StandardEdge;
-import org.janusgraph.graphdb.relations.StandardVertexProperty;
 import org.janusgraph.graphdb.transaction.addedrelations.AddedRelationsContainer;
 import org.janusgraph.graphdb.transaction.addedrelations.ConcurrentBufferAddedRelations;
 import org.janusgraph.graphdb.transaction.addedrelations.SimpleBufferAddedRelations;
@@ -662,12 +659,40 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
         return uniqueLock;
     }
 
+    private void checkPropertyConstraintForVertexOrCreateConstraint(VertexLabel vertexLabel, PropertyKey key) {
+        if (config.hasDisabledSchemaConstraints()) return;
+        if (vertexLabel instanceof BaseVertexLabel) return;
+        Collection<PropertyKey> propertyKeys = vertexLabel.mappedProperties();
+        if (propertyKeys.contains(key)) return;
+        config.getAutoSchemaMaker().makePropertyConstraintForVertex(vertexLabel, key, this);
+    }
+
+    public void checkPropertyConstraintForEdgeOrCreateConstraint(EdgeLabel edgeLabel, PropertyKey key) {
+        if (config.hasDisabledSchemaConstraints()) return;
+        if (edgeLabel instanceof BaseLabel) return;
+        Collection<PropertyKey> propertyKeys = edgeLabel.mappedProperties();
+        if (propertyKeys.contains(key)) return;
+        config.getAutoSchemaMaker().makePropertyConstraintForEdge(edgeLabel, key, this);
+    }
+
+    private void checkConnectionConstraintOrCreateConstraint(VertexLabel outVertexLabel, VertexLabel inVertexLabel, EdgeLabel edgeLabel) {
+        if (config.hasDisabledSchemaConstraints()) return;
+        if (outVertexLabel instanceof BaseVertexLabel) return;
+        if (inVertexLabel instanceof BaseVertexLabel) return;
+        Collection<VertexConnection> vertexConnections = outVertexLabel.mappedConnections();
+        for (VertexConnection vertexConnection : vertexConnections) {
+            if (vertexConnection.getIncomingVertexLabel() != inVertexLabel) continue;
+            if (vertexConnection.getEdgeLabel().equals(edgeLabel.name())) return;
+        }
+        config.getAutoSchemaMaker().makeConnectionConstraint(edgeLabel, outVertexLabel, inVertexLabel, this);
+    }
 
     public JanusGraphEdge addEdge(JanusGraphVertex outVertex, JanusGraphVertex inVertex, EdgeLabel label) {
         verifyWriteAccess(outVertex, inVertex);
         outVertex = ((InternalVertex) outVertex).it();
         inVertex = ((InternalVertex) inVertex).it();
         Preconditions.checkNotNull(label);
+        checkConnectionConstraintOrCreateConstraint(outVertex.vertexLabel(), inVertex.vertexLabel(), label);
         Multiplicity multiplicity = label.multiplicity();
         TransactionLock uniqueLock = getUniquenessLock(outVertex, (InternalRelationType) label,inVertex);
         uniqueLock.lock(LOCK_TIMEOUT);
@@ -712,11 +737,12 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     public JanusGraphVertexProperty addProperty(VertexProperty.Cardinality cardinality, JanusGraphVertex vertex, PropertyKey key, Object value) {
         if (key.cardinality().convert()!=cardinality && cardinality!=VertexProperty.Cardinality.single)
-                throw new SchemaViolationException(String.format("Key is defined for %s cardinality which conflicts with specified: %s",key.cardinality(),cardinality));
+            throw new SchemaViolationException("Key is defined for %s cardinality which conflicts with specified: %s",key.cardinality(),cardinality);
         verifyWriteAccess(vertex);
         Preconditions.checkArgument(!(key instanceof ImplicitKey),"Cannot create a property of implicit type: %s",key.name());
         vertex = ((InternalVertex) vertex).it();
         Preconditions.checkNotNull(key);
+        checkPropertyConstraintForVertexOrCreateConstraint(vertex.vertexLabel(), key);
         final Object normalizedValue = verifyAttribute(key, value);
         Cardinality keyCardinality = key.cardinality();
 
@@ -859,6 +885,38 @@ public class StandardJanusGraphTx extends JanusGraphBlueprintsTransaction implem
 
     public EdgeLabel makeEdgeLabel(String name, TypeDefinitionMap definition) {
         return (EdgeLabel) makeSchemaVertex(JanusGraphSchemaCategory.EDGELABEL, name, definition);
+    }
+
+
+    public JanusGraphEdge addSchemaEdge(JanusGraphVertex out, JanusGraphVertex in, TypeDefinitionCategory def, Object modifier) {
+        assert def.isEdge();
+        JanusGraphEdge edge = addEdge(out, in, BaseLabel.SchemaDefinitionEdge);
+        TypeDefinitionDescription desc = new TypeDefinitionDescription(def, modifier);
+        edge.property(BaseKey.SchemaDefinitionDesc.name(), desc);
+        return edge;
+    }
+
+    @Override
+    public VertexLabel addProperties(VertexLabel vertexLabel, PropertyKey... keys) {
+        for (PropertyKey key : keys) {
+            addSchemaEdge(vertexLabel, key, TypeDefinitionCategory.PROPERTY_KEY_EDGE, null);
+        }
+        return vertexLabel;
+    }
+
+    @Override
+    public EdgeLabel addProperties(EdgeLabel edgeLabel, PropertyKey... keys) {
+        for (PropertyKey key : keys) {
+            addSchemaEdge(edgeLabel, key, TypeDefinitionCategory.PROPERTY_KEY_EDGE, null);
+        }
+        return edgeLabel;
+    }
+
+    @Override
+    public EdgeLabel addConnection(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel) {
+        addSchemaEdge(outVLabel, inVLabel, TypeDefinitionCategory.CONNECTION_EDGE, edgeLabel.name());
+        addSchemaEdge(edgeLabel, outVLabel, TypeDefinitionCategory.UPDATE_CONNECTION_EDGE, null);
+        return edgeLabel;
     }
 
     public JanusGraphSchemaVertex getSchemaVertex(String schemaName) {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardTransactionBuilder.java
@@ -47,6 +47,8 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
 
     private final DefaultSchemaMaker defaultSchemaMaker;
 
+    private boolean hasDisabledSchemaConstraints = true;
+
     private boolean verifyExternalVertexExistence = true;
 
     private boolean verifyInternalVertexExistence = false;
@@ -93,6 +95,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         if (graphConfig.isBatchLoading()) enableBatchLoading();
         this.graph = graph;
         this.defaultSchemaMaker = graphConfig.getDefaultSchemaMaker();
+        this.hasDisabledSchemaConstraints = graphConfig.hasDisabledSchemaConstraints();
         this.assignIDsImmediately = graphConfig.hasFlushIDs();
         this.forceIndexUsage = graphConfig.hasForceIndexUsage();
         this.groupName = graphConfig.getMetricsPrefix();
@@ -111,6 +114,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         if (graphConfig.isBatchLoading()) enableBatchLoading();
         this.graph = graph;
         this.defaultSchemaMaker = graphConfig.getDefaultSchemaMaker();
+        this.hasDisabledSchemaConstraints = graphConfig.hasDisabledSchemaConstraints();
         this.assignIDsImmediately = graphConfig.hasFlushIDs();
         this.forceIndexUsage = graphConfig.hasForceIndexUsage();
         this.groupName = graphConfig.getMetricsPrefix();
@@ -235,7 +239,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
                 propertyPrefetching, singleThreaded, threadBound, getTimestampProvider(), userCommitTime,
                 indexCacheWeight, getVertexCacheSize(), getDirtyVertexSize(),
                 logIdentifier, restrictedPartitions, groupName,
-                defaultSchemaMaker, customOptions);
+                defaultSchemaMaker, hasDisabledSchemaConstraints, customOptions);
         return graph.newTransaction(immutable);
     }
 
@@ -285,6 +289,11 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     @Override
     public final DefaultSchemaMaker getAutoSchemaMaker() {
         return defaultSchemaMaker;
+    }
+
+    @Override
+    public boolean hasDisabledSchemaConstraints() {
+        return hasDisabledSchemaConstraints;
     }
 
     @Override
@@ -391,6 +400,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         private final String logIdentifier;
         private final int[] restrictedPartitions;
         private final DefaultSchemaMaker defaultSchemaMaker;
+        private boolean hasDisabledSchemaConstraints = true;
 
         private final BaseTransactionConfig handleConfig;
 
@@ -406,7 +416,9 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
                 boolean isThreadBound, TimestampProvider times, Instant commitTime,
                 long indexCacheWeight, int vertexCacheSize, int dirtyVertexSize, String logIdentifier,
                 int[] restrictedPartitions,
-                String groupName, DefaultSchemaMaker defaultSchemaMaker,
+                String groupName,
+                DefaultSchemaMaker defaultSchemaMaker,
+                boolean hasDisabledSchemaConstraints,
                 Configuration customOptions) {
             this.isReadOnly = isReadOnly;
             this.hasEnabledBatchLoading = hasEnabledBatchLoading;
@@ -426,6 +438,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
             this.logIdentifier = logIdentifier;
             this.restrictedPartitions=restrictedPartitions;
             this.defaultSchemaMaker = defaultSchemaMaker;
+            this.hasDisabledSchemaConstraints = hasDisabledSchemaConstraints;
             this.handleConfig = new StandardBaseTransactionConfig.Builder()
                     .commitTime(commitTime)
                     .timestampProvider(times)
@@ -476,6 +489,11 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         @Override
         public DefaultSchemaMaker getAutoSchemaMaker() {
             return defaultSchemaMaker;
+        }
+
+        @Override
+        public boolean hasDisabledSchemaConstraints() {
+            return hasDisabledSchemaConstraints;
         }
 
         @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/TransactionConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/TransactionConfiguration.java
@@ -92,6 +92,13 @@ public interface TransactionConfiguration extends BaseTransactionConfig {
     DefaultSchemaMaker getAutoSchemaMaker();
 
     /**
+     * Allows to disable schema constraints.
+     *
+     * @return True, if schema constraints should not be applied, else false.
+     */
+    boolean hasDisabledSchemaConstraints();
+
+    /**
      * Whether the graph transaction is configured to verify that an added key does not yet exist in the database.
      *
      * @return True, if vertex existence is verified, else false

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeDefinitionCategory.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/TypeDefinitionCategory.java
@@ -65,15 +65,18 @@ public enum TypeDefinitionCategory {
     STATIC(Boolean.class),
 
     //Schema Edges
+    PROPERTY_KEY_EDGE(),
+    CONNECTION_EDGE(RelationCategory.EDGE, String.class),
+    UPDATE_CONNECTION_EDGE(),
     RELATIONTYPE_INDEX(),
     TYPE_MODIFIER(),
-    INDEX_FIELD(RelationCategory.EDGE,Parameter[].class),
+    INDEX_FIELD(RelationCategory.EDGE, Parameter[].class),
     INDEX_SCHEMA_CONSTRAINT();
 
     public static final Set<TypeDefinitionCategory> PROPERTYKEY_DEFINITION_CATEGORIES = ImmutableSet.of(STATUS, INVISIBLE, SORT_KEY, SORT_ORDER, SIGNATURE, MULTIPLICITY, DATATYPE);
     public static final Set<TypeDefinitionCategory> EDGELABEL_DEFINITION_CATEGORIES = ImmutableSet.of(STATUS, INVISIBLE, SORT_KEY, SORT_ORDER, SIGNATURE, MULTIPLICITY, UNIDIRECTIONAL);
     public static final Set<TypeDefinitionCategory> INDEX_DEFINITION_CATEGORIES = ImmutableSet.of(STATUS, ELEMENT_CATEGORY,INDEX_CARDINALITY,INTERNAL_INDEX, BACKING_INDEX,INDEXSTORE_NAME);
-    public static final Set<TypeDefinitionCategory> VERTEXLABEL_DEFINITION_CATEGORIES = ImmutableSet.of(PARTITIONED,STATIC);
+    public static final Set<TypeDefinitionCategory> VERTEXLABEL_DEFINITION_CATEGORIES = ImmutableSet.of(PARTITIONED, STATIC);
     public static final Set<TypeDefinitionCategory> TYPE_MODIFIER_DEFINITION_CATEGORIES;
 
     static {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/VertexLabelVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/VertexLabelVertex.java
@@ -14,9 +14,17 @@
 
 package org.janusgraph.graphdb.types;
 
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.VertexConnection;
+import org.janusgraph.core.VertexLabel;
 import org.janusgraph.graphdb.internal.InternalVertexLabel;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.vertices.JanusGraphSchemaVertex;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -36,6 +44,20 @@ public class VertexLabelVertex extends JanusGraphSchemaVertex implements Interna
     @Override
     public boolean isStatic() {
         return getDefinition().getValue(TypeDefinitionCategory.STATIC, Boolean.class);
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return StreamSupport.stream( getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT).spliterator(), false)
+            .map(entry -> (PropertyKey) entry.getSchemaType())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<VertexConnection> mappedConnections() {
+        return StreamSupport.stream(getRelated(TypeDefinitionCategory.CONNECTION_EDGE, Direction.OUT).spliterator(), false)
+            .map(entry -> new VertexConnection((VertexLabel) entry.getSchemaType(), (String) entry.getModifier()))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseLabel.java
@@ -14,10 +14,14 @@
 
 package org.janusgraph.graphdb.types.system;
 
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.core.EdgeLabel;
 import org.janusgraph.core.Multiplicity;
+import org.janusgraph.core.PropertyKey;
 import org.janusgraph.graphdb.internal.JanusGraphSchemaCategory;
-import org.apache.tinkerpop.gremlin.structure.Direction;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class BaseLabel extends BaseRelationType implements EdgeLabel {
 
@@ -45,6 +49,11 @@ public class BaseLabel extends BaseRelationType implements EdgeLabel {
     @Override
     public Multiplicity multiplicity() {
         return multiplicity;
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return new ArrayList<>();
     }
 
     @Override

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseVertexLabel.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/system/BaseVertexLabel.java
@@ -14,8 +14,13 @@
 
 package org.janusgraph.graphdb.types.system;
 
-import org.janusgraph.graphdb.internal.InternalVertexLabel;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.VertexConnection;
+import org.janusgraph.graphdb.internal.InternalVertexLabel;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -58,5 +63,15 @@ public class BaseVertexLabel extends EmptyVertex implements InternalVertexLabel 
     @Override
     public String toString() {
         return name();
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Collection<VertexConnection> mappedConnections() {
+        return new ArrayList<>();
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/typemaker/DisableDefaultSchemaMaker.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/typemaker/DisableDefaultSchemaMaker.java
@@ -15,10 +15,7 @@
 package org.janusgraph.graphdb.types.typemaker;
 
 import org.janusgraph.core.*;
-import org.janusgraph.core.schema.DefaultSchemaMaker;
-import org.janusgraph.core.schema.EdgeLabelMaker;
-import org.janusgraph.core.schema.PropertyKeyMaker;
-import org.janusgraph.core.schema.VertexLabelMaker;
+import org.janusgraph.core.schema.*;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -54,5 +51,23 @@ public class DisableDefaultSchemaMaker implements DefaultSchemaMaker {
     @Override
     public boolean ignoreUndefinedQueryTypes() {
         return false;
+    }
+
+    @Override
+    public void makePropertyConstraintForEdge(EdgeLabel edgeLabel, PropertyKey key, SchemaManager manager) {
+        throw new IllegalArgumentException(
+            String.format("Property Key constraint does not exist for given Edge Label [%s] and property key [%s].", edgeLabel, key));
+    }
+
+    @Override
+    public void makePropertyConstraintForVertex(VertexLabel vertexLabel, PropertyKey key, SchemaManager manager) {
+        throw new IllegalArgumentException(
+            String.format("Property Key constraint does not exist for given Vertex Label [%s] and property key [%s].", vertexLabel, key));
+    }
+
+    @Override
+    public void makeConnectionConstraint(EdgeLabel edgeLabel, VertexLabel outVLabel, VertexLabel inVLabel, SchemaManager manager) {
+        throw new IllegalArgumentException(
+            String.format("Connection constraint does not exist for given Edge Label [%s], outgoing Vertex Label [%s] and incoming Vertex Label [%s]", edgeLabel, outVLabel, inVLabel));
     }
 }

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/EdgeLabelVertex.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/types/vertices/EdgeLabelVertex.java
@@ -14,10 +14,15 @@
 
 package org.janusgraph.graphdb.types.vertices;
 
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.PropertyKey;
 import org.janusgraph.graphdb.transaction.StandardJanusGraphTx;
 import org.janusgraph.graphdb.types.TypeDefinitionCategory;
-import org.apache.tinkerpop.gremlin.structure.Direction;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class EdgeLabelVertex extends RelationTypeVertex implements EdgeLabel {
 
@@ -34,6 +39,13 @@ public class EdgeLabelVertex extends RelationTypeVertex implements EdgeLabel {
     public boolean isUnidirected() {
         return isUnidirected(Direction.OUT);
 
+    }
+
+    @Override
+    public Collection<PropertyKey> mappedProperties() {
+        return StreamSupport.stream( getRelated(TypeDefinitionCategory.PROPERTY_KEY_EDGE, Direction.OUT).spliterator(), false)
+            .map(entry -> (PropertyKey) entry.getSchemaType())
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
+++ b/janusgraph-test/src/main/java/org/janusgraph/graphdb/JanusGraphTest.java
@@ -55,7 +55,6 @@ import org.janusgraph.core.schema.SchemaStatus;
 import org.janusgraph.core.schema.JanusGraphIndex;
 import org.janusgraph.core.schema.JanusGraphManagement;
 import org.janusgraph.core.schema.JanusGraphSchemaType;
-import org.janusgraph.core.util.JanusGraphCleanup;
 import org.janusgraph.core.util.ManagementUtil;
 import org.janusgraph.diskstorage.Backend;
 import org.janusgraph.diskstorage.BackendException;
@@ -3333,6 +3332,280 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
 
     }
 
+    private void createStrictSchemaForVertexProperties() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+        VertexLabel label = mgmt.makeVertexLabel("user").make();
+        PropertyKey id = mgmt.makePropertyKey("id").cardinality(Cardinality.SINGLE).dataType(Integer.class).make();
+        mgmt.makePropertyKey("test").cardinality(Cardinality.SINGLE).dataType(Integer.class).make();
+        mgmt.addProperties(label, id);
+        finishSchema();
+    }
+
+    @Test
+    public void testEnforcedSchemaAllowsDefinedVertexProperties() {
+        createStrictSchemaForVertexProperties();
+
+        JanusGraphVertex v = tx.addVertex("user");
+        v.property("id", 10);
+    }
+
+    @Test
+    public void testSchemaIsEnforcedForVertexProperties() {
+        createStrictSchemaForVertexProperties();
+
+        JanusGraphVertex v = tx.addVertex("user");
+        try {
+            v.property("test", 10);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testAllowDisablingSchemaConstraintForVertexProperty() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), false);
+        mgmt.makeVertexLabel("user").make();
+        mgmt.makePropertyKey("test").cardinality(Cardinality.SINGLE).dataType(Integer.class).make();
+        finishSchema();
+
+        JanusGraphVertex v = tx.addVertex("user");
+        v.property("test", 10);
+    }
+
+    @Test
+    public void testAllowDisablingSchemaConstraintForConnection() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), false);
+        mgmt.makeVertexLabel("user").make();
+        mgmt.makeEdgeLabel("knows").make();
+        finishSchema();
+
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2);
+    }
+
+    @Test
+    public void testAllowDisablingSchemaConstraintForEdgeProperty() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), false);
+        mgmt.makeVertexLabel("user").make();
+        mgmt.makeEdgeLabel("knows").make();
+        mgmt.makePropertyKey("test").cardinality(Cardinality.SINGLE).dataType(Integer.class).make();
+        finishSchema();
+
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2, "test", 10);
+    }
+
+    @Test
+    public void testAutoSchemaMakerForVertexPropertyConstraints() {
+        clopen(option(SCHEMA_CONSTRAINTS), true);
+        JanusGraphVertex v1 = tx.addVertex("user");
+        v1.property("test", 10);
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+
+        JanusGraphVertex v2 = tx.addVertex("user");
+        v2.property("test", 10);
+
+        try {
+            v2.property("id", 10);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    private void createStrictSchemaForEdgeProperties() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+        VertexLabel user = mgmt.makeVertexLabel("user").make();
+        EdgeLabel edge = mgmt.makeEdgeLabel("knows").make();
+        PropertyKey id = mgmt.makePropertyKey("id").cardinality(Cardinality.SINGLE).dataType(Integer.class).make();
+        mgmt.makePropertyKey("test").cardinality(Cardinality.SINGLE).dataType(Integer.class).make();
+        mgmt.addProperties(edge, id);
+        mgmt.addConnection(edge, user, user);
+        finishSchema();
+    }
+
+    @Test
+    public void testEnforcedSchemaAllowsDefinedEdgeProperties() {
+        createStrictSchemaForEdgeProperties();
+
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2, "id", 10);
+    }
+
+    @Test
+    public void testSchemaIsEnforcedForEdgeProperties() {
+        createStrictSchemaForEdgeProperties();
+
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("user");
+        try {
+            v1.addEdge("knows", v2, "test", 10);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testAutoSchemaMakerForEdgePropertyConstraints() {
+        clopen(option(SCHEMA_CONSTRAINTS), true);
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2, "id", 10);
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+
+        v1 = tx.addVertex("user");
+        v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2, "id", 10);
+
+        try {
+            v1.addEdge("knows", v2, "test", 10);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    private void createStrictSchemaForConnections() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+        VertexLabel user = mgmt.makeVertexLabel("user").make();
+        VertexLabel company = mgmt.makeVertexLabel("company").make();
+        EdgeLabel edge = mgmt.makeEdgeLabel("knows").make();
+        mgmt.makeEdgeLabel("buys").make();
+        mgmt.addConnection(edge, user, company);
+        finishSchema();
+    }
+
+    @Test
+    public void testEnforcedSchemaAllowsDefinedConnections() {
+        createStrictSchemaForConnections();
+
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("company");
+        v1.addEdge("knows", v2);
+    }
+
+    @Test
+    public void testSchemaIsEnforcedForConnections() {
+        createStrictSchemaForConnections();
+
+        JanusGraphVertex v1 = tx.addVertex("user");
+        try {
+            v1.addEdge("buys", v1);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        JanusGraphVertex v2 = tx.addVertex("company");
+        try {
+            v2.addEdge("knows", v1);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testAutoSchemaMakerForConnectionConstraints() {
+        clopen(option(SCHEMA_CONSTRAINTS), true);
+        JanusGraphVertex v1 = tx.addVertex("user");
+        JanusGraphVertex v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2);
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+
+        v1 = tx.addVertex("user");
+        v2 = tx.addVertex("user");
+        v1.addEdge("knows", v2);
+
+        try {
+            v1.addEdge("has", v2);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testSupportChangeNameOfEdgeAndUpdateConnections() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+        VertexLabel user = mgmt.makeVertexLabel("V1").make();
+        VertexLabel company = mgmt.makeVertexLabel("V2").make();
+        EdgeLabel edge = mgmt.makeEdgeLabel("E1").make();
+        mgmt.addConnection(edge, user, company);
+        finishSchema();
+
+        JanusGraphVertex v1 = tx.addVertex("V1");
+        JanusGraphVertex v2 = tx.addVertex("V2");
+        v1.addEdge("E1", v2);
+        newTx();
+
+        edge = mgmt.getEdgeLabel("E1");
+        mgmt.changeName(edge, "E2");
+        mgmt.commit();
+
+        JanusGraphVertex v3 = tx.addVertex("V1");
+        JanusGraphVertex v4 = tx.addVertex("V2");
+        v3.addEdge("E2", v4);
+    }
+
+    private void createStrictSchemaForComplexConnections() {
+        clopen(option(AUTO_TYPE), "none", option(SCHEMA_CONSTRAINTS), true);
+        VertexLabel v1 = mgmt.makeVertexLabel("V1").make();
+        VertexLabel v2 = mgmt.makeVertexLabel("V2").make();
+        VertexLabel v3 = mgmt.makeVertexLabel("V3").make();
+        VertexLabel v4 = mgmt.makeVertexLabel("V4").make();
+        EdgeLabel e1 = mgmt.makeEdgeLabel("E1").make();
+        EdgeLabel e2 = mgmt.makeEdgeLabel("E2").make();
+        mgmt.addConnection(e1, v1, v2);
+        mgmt.addConnection(e1, v3, v4);
+        mgmt.addConnection(e2, v1, v4);
+        mgmt.addConnection(e2, v3, v2);
+        finishSchema();
+    }
+
+    @Test
+    public void testAllowEnforcedComplexConnections() {
+        createStrictSchemaForComplexConnections();
+
+        JanusGraphVertex v1 = tx.addVertex("V1");
+        JanusGraphVertex v2 = tx.addVertex("V2");
+        JanusGraphVertex v3 = tx.addVertex("V3");
+        JanusGraphVertex v4 = tx.addVertex("V4");
+        v1.addEdge("E1", v2);
+        v3.addEdge("E1", v4);
+        v3.addEdge("E2", v2);
+        v1.addEdge("E2", v4);
+    }
+
+    @Test
+    public void testEnforceComplexConnections() {
+        createStrictSchemaForComplexConnections();
+
+        JanusGraphVertex v1 = tx.addVertex("V1");
+        JanusGraphVertex v2 = tx.addVertex("V2");
+        JanusGraphVertex v3 = tx.addVertex("V3");
+        JanusGraphVertex v4 = tx.addVertex("V4");
+        try {
+            v1.addEdge("E2", v2);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+        try {
+            v3.addEdge("E2", v4);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+        try {
+            v3.addEdge("E1", v2);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+        try {
+            v1.addEdge("E1", v4);
+            fail("This should never reached!");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+
     private boolean isSortedByID(VertexList vl) {
         for (int i = 1; i < vl.size(); i++) {
             if (vl.getID(i - 1) > vl.getID(i)) return false;
@@ -3679,6 +3952,7 @@ public abstract class JanusGraphTest extends JanusGraphBaseTest {
         PropertyKey weight = tx.makePropertyKey("weight").dataType(Float.class).cardinality(Cardinality.SINGLE).make();
         EdgeLabel knows = tx.makeEdgeLabel("knows").make();
         JanusGraphVertex n1 = tx.addVertex("weight", 10.5);
+        tx.addProperties(knows, weight);
         newTx();
 
         final Instant txTimes[] = new Instant[4];

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/inmemory/InMemoryGraphTest.java
@@ -102,4 +102,12 @@ public class InMemoryGraphTest extends JanusGraphTest {
     @Override
     public void testClearStorage() {}
 
+    @Override
+    public void testAutoSchemaMakerForEdgePropertyConstraints() {}
+
+    @Override
+    public void testAutoSchemaMakerForVertexPropertyConstraints() {}
+
+    @Override
+    public void testAutoSchemaMakerForConnectionConstraints() {}
 }


### PR DESCRIPTION
Fixes 880.

# Design Decisions
* Extension and usage of SchemaMaker
* Connection constrains are defined using two schema edges, one between out and in Vertex and one between the edge and out vertex. The first edge has a property with the label of the edge. 

# Alternative Idea
Create a new SchemaVertex for a connection and make edges to an out-VertexLabel, an in-VertexLabel, and EdgeLabel. This alternative would allow to remove an extra step during an update, if an EdgeLabel is renamed.

# Todo
* [ ] documentation (wait for review comments on current implementation)